### PR TITLE
Perhaps the bug?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/remix-synth.Rproj
+++ b/remix-synth.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: No
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/synthcode.r
+++ b/synthcode.r
@@ -8,6 +8,7 @@
 #Libraries needed
 library(readstata13)
 library(Synth)
+
 #> ##
 #> ## Synth Package: Implements Synthetic Control Methods.
 #> ## See http://www.mit.edu/~jhainm/software.htm for additional information.

--- a/troubleshooting-synth.R
+++ b/troubleshooting-synth.R
@@ -8,9 +8,8 @@ library(Synth)
 
 texas <- read.dta13("texas.dta")
 
-
 # Prep Data
-
+data("basque")
 # prep data ---------------------------------------------------------------
 
 dataprep.out = dataprep(
@@ -122,9 +121,10 @@ if (0 %in% apply(X0, 1, sd))
 }
 
 # collinearity check
-#check <- try(solve(t(X0)%*%X0),silent=TRUE)
-# if(class(check)=="try-error")
-#  {stop("\n Some of the predictors in X0 are collinear (t(X0)%*%X0) not invertible")}
+check <- try(solve(t(X0)%*%X0),silent=TRUE)
+if(class(check)=="try-error"){
+	stop("\n Some of the predictors in X0 are collinear (t(X0)%*%X0) not invertible")
+	}
 
 # Normalize X
 nvarsV <- dim(X0)[1]
@@ -194,6 +194,18 @@ if (is.null(custom.v) & nrow(X0) != 1)
 	if (sum(optimxmethod %in% c("All")) == 1) {
 		all.methods <- TRUE
 	}
+
+
+
+
+# FAILURE HERE ------------------------------------------------------------
+# This is the function that is failing. IT does not return a valid results
+# Potential Issues.
+# We have some matrices that cannot be inverted which might be issue
+solve(t(X0.scaled)%*%X0.scaled)
+
+solve(t(X1.scaled)%*%X1.scaled)
+	
 	rgV.optim.1 <- optimx::optimx(
 		par = SV1,
 		fn = fn.V,
@@ -218,9 +230,8 @@ if (is.null(custom.v) & nrow(X0) != 1)
 		bound.ipop = Bound.ipop
 	)
 	# get minimum
-	if (verbose == TRUE) {
-		print(rgV.optim.1)
-	}
+	print(rgV.optim.1)
+	
 	rgV.optim.1 <- collect.optimx(rgV.optim.1, "min")
 	
 	# second set of starting values: regression method
@@ -268,9 +279,8 @@ if (is.null(custom.v) & nrow(X0) != 1)
 			bound.ipop = Bound.ipop
 		)
 		# get minimum
-		if (verbose == TRUE) {
 			print(rgV.optim.2)
-		}
+			
 		rgV.optim.2 <- collect.optimx(rgV.optim.2, "min")
 		
 		# ouput

--- a/troubleshooting-synth.R
+++ b/troubleshooting-synth.R
@@ -1,0 +1,413 @@
+
+# libraries ---------------------------------------------------------------
+
+library(readstata13)
+library(Synth)
+
+# raw data ----------------------------------------------------------------
+
+texas <- read.dta13("texas.dta")
+
+
+# Prep Data
+
+# prep data ---------------------------------------------------------------
+
+dataprep.out = dataprep(
+	foo = texas,
+	predictors = c("poverty", "income", "ur"),
+	predictors.op = "mean",
+	time.predictors.prior = 1985:1993,
+	special.predictors = list(
+		list("bmprison", 1988, "mean"),
+		list("alcohol", 1990, "mean"),
+		list("aidscapita",  1990:1991, "mean"),
+		list("black", 1990:1992, "mean"),
+		list("perc1519", 1990, "mean")),
+	dependent = "bmprison",
+	unit.variable = "statefip",
+	unit.names.variable = "state",
+	time.variable = "year",
+	treatment.identifier = 37,
+	controls.identifier = c(1,2,4:6,8:13,15:36,38:42,44:47,49:51,53:56), 
+	time.optimize.ssr = 1985:1993,
+	time.plot = 1985:2000
+)
+
+
+# synthetic controls ------------------------------------------------------
+
+# Step through `synth` function
+data.prep.obj = dataprep.out
+X1 = NULL
+X0 = NULL
+Z0 = NULL
+Z1 = NULL
+custom.v = NULL
+optimxmethod = c("BFGS")
+genoud = FALSE
+quadopt = "ipop"
+Margin.ipop = 0.0005
+Sigf.ipop = 5
+Bound.ipop = 10
+verbose = FALSE
+
+
+# Retrieve dataprep objects
+if (is.null(data.prep.obj) == FALSE)
+{
+	cat("\nX1, X0, Z1, Z0 all come directly from dataprep object.\n\n")
+	X1 <- data.prep.obj$X1
+	Z1 <- data.prep.obj$Z1
+	X0 <- data.prep.obj$X0
+	Z0 <- data.prep.obj$Z0
+} else {
+	cat("X1,X0,Z1,Z0 were individually input (not dataprep object.)\n\n")
+}
+
+# routine checks
+store <- list(X1 = X1,
+							X0 = X0,
+							Z1 = Z1,
+							Z0 = Z0)
+for (i in 1:4) {
+	if (is.null(store[[i]]))
+	{
+		stop(paste("\n", names(store)[i], "is missing \n"))
+	}
+	if (sum(is.na(store[[i]])) > 0)
+	{
+		stop(paste("\n NAs in", names(store)[i], "\n"))
+	}
+	if (is.matrix(store[[i]]) == FALSE)
+	{
+		stop(paste("\n", names(store)[i], "is not a matrix object\n"))
+	}
+}
+
+# geometry checks
+if (ncol(X1) != 1) {
+	stop("\n Please specify only one treated unit: X1 has to have ncol= 1")
+}
+if (ncol(Z1) != 1) {
+	stop("\n Please specify only one treated unit: Z1 has to have ncol= 1")
+}
+
+if (ncol(X0) < 2) {
+	stop("\n Please specify at least two control units: X0 has to have ncol >= 2 ")
+}
+if (ncol(Z0) < 2) {
+	stop("\n Please specify only one treated unit: Z0 has to have ncol >= 2")
+}
+
+if (nrow(Z0) != nrow(Z1)) {
+	stop("\n Different number of periods for treated and controls: nrow(Z0) unequal nrow(Z1)")
+}
+if (nrow(X0) != nrow(X1)) {
+	stop("\n Different number of predictors for treated and controls: nrow(X0) unequal nrow(X1)")
+}
+
+if (nrow(X0) == 0) {
+	stop("No predictors specified. Please specify at least on predictor")
+}
+if (nrow(Z0) == 0) {
+	stop("No periods specified for Z1 and Z0. Please specify at least on period")
+}
+
+if (0 %in% apply(X0, 1, sd))
+{
+	stop(
+		"\n At least one predictor in X0 has no variation across control units. Please remove this predictor."
+	)
+}
+
+# collinearity check
+#check <- try(solve(t(X0)%*%X0),silent=TRUE)
+# if(class(check)=="try-error")
+#  {stop("\n Some of the predictors in X0 are collinear (t(X0)%*%X0) not invertible")}
+
+# Normalize X
+nvarsV <- dim(X0)[1]
+big.dataframe <- cbind(X0, X1)
+divisor <- sqrt(apply(big.dataframe, 1, var))
+scaled.matrix <-
+	t(t(big.dataframe) %*% (1 / (divisor) *
+														diag(rep(
+															dim(big.dataframe)[1], 1
+														))))
+
+X0.scaled <- scaled.matrix[, c(1:(dim(X0)[2]))]
+if (is.vector(X0.scaled) == TRUE)
+{
+	X0.scaled <- t(as.matrix(X0.scaled))
+}
+X1.scaled <- scaled.matrix[, dim(scaled.matrix)[2]]
+
+
+# check if custom v weights are supplied or
+# if only on predictor is specified,
+# we jump to quadratic optimization over W weights
+# if not start optimization over V and W
+if (is.null(custom.v) & nrow(X0) != 1)
+{
+	# two attemps for best V are made:
+	# equal weights and regression based starting values
+	cat("\n****************",
+			"\n searching for synthetic control unit  \n",
+			"\n")
+	
+	if (genoud == TRUE)
+		# if user wants genoud as well
+	{
+		require(rgenoud)                # we run genoud first
+		cat("\n****************",
+				"\n genoud() requested for optimization\n",
+				"\n")
+		
+		rgV.genoud <- genoud(
+			fn.V,
+			nvarsV,
+			X0.scaled = X0.scaled,
+			X1.scaled = X1.scaled,
+			Z0 = Z0,
+			Z1 = Z1,
+			quadopt = quadopt,
+			margin.ipop = Margin.ipop,
+			sigf.ipop = Sigf.ipop,
+			bound.ipop = Bound.ipop
+		)
+		SV1 <- rgV.genoud$par  # and use these as starting values
+		
+		cat(
+			"\n****************",
+			"\n genoud() finished, now running local optimization using optim()\n",
+			"\n"
+		)
+		
+	} else {
+		# if we don't use genoud first: set of starting values: equal weights
+		SV1 <- rep(1 / nvarsV, nvarsV)
+	}
+	
+	# now we run optimization
+	all.methods <- FALSE
+	if (sum(optimxmethod %in% c("All")) == 1) {
+		all.methods <- TRUE
+	}
+	rgV.optim.1 <- optimx::optimx(
+		par = SV1,
+		fn = fn.V,
+		gr = NULL,
+		hess = NULL,
+		method = optimxmethod,
+		itnmax = 1e5,
+		hessian = FALSE,
+		control = list(
+			kkt = FALSE,
+			starttests = FALSE,
+			dowarn = FALSE,
+			all.methods = all.methods
+		),
+		X0.scaled = X0.scaled,
+		X1.scaled = X1.scaled,
+		Z0 = Z0,
+		Z1 = Z1,
+		quadopt = quadopt,
+		margin.ipop = Margin.ipop,
+		sigf.ipop = Sigf.ipop,
+		bound.ipop = Bound.ipop
+	)
+	# get minimum
+	if (verbose == TRUE) {
+		print(rgV.optim.1)
+	}
+	rgV.optim.1 <- collect.optimx(rgV.optim.1, "min")
+	
+	# second set of starting values: regression method
+	# will sometimes not work because of collinear Xs
+	# so it's wrapped in a try command
+	Xall <- cbind(X1.scaled, X0.scaled)
+	Xall <- cbind(rep(1, ncol(Xall)), t(Xall))
+	Zall <- cbind(Z1, Z0)
+	Beta <-try(solve(t(Xall) %*% Xall) %*% t(Xall) %*% t(Zall), silent = TRUE)
+	Beta
+	# if inverses did not work, we
+	# stick with first results
+	if (inherits(Beta, "try-error"))
+	{
+		rgV.optim <- rgV.optim.1
+		rgV.optim
+	} else {
+		# otherwise we run a second optimization with regression starting values
+		Beta <- Beta[-1, ]
+		V    <- Beta %*% t(Beta)
+		SV2  <- diag(V)
+		SV2 <- SV2 / sum(SV2)
+		
+		rgV.optim.2 <- optimx::optimx(
+			par = SV2,
+			fn = fn.V,
+			gr = NULL,
+			hess = NULL,
+			method = optimxmethod,
+			itnmax = NULL,
+			hessian = FALSE,
+			control = list(
+				kkt = FALSE,
+				starttests = FALSE,
+				dowarn = FALSE,
+				all.methods = all.methods
+			),
+			X0.scaled = X0.scaled,
+			X1.scaled = X1.scaled,
+			Z0 = Z0,
+			Z1 = Z1,
+			quadopt = quadopt,
+			margin.ipop = Margin.ipop,
+			sigf.ipop = Sigf.ipop,
+			bound.ipop = Bound.ipop
+		)
+		# get minimum
+		if (verbose == TRUE) {
+			print(rgV.optim.2)
+		}
+		rgV.optim.2 <- collect.optimx(rgV.optim.2, "min")
+		
+		# ouput
+		if (verbose == TRUE) {
+			cat("\n Equal weight loss is:", rgV.optim.1$value, "\n")
+			cat("\n Regression Loss is:", rgV.optim.2$value, "\n")
+		}
+		# and keep the better optim results
+		if (rgV.optim.1$value < rgV.optim.2$value)
+		{
+			rgV.optim <- rgV.optim.1
+		} else {
+			rgV.optim <- rgV.optim.2
+		}
+	} # close if statement for second regression based optimization attempt
+	
+	# final V weights from optimization
+	solution.v   <- abs(rgV.optim$par) / sum(abs(rgV.optim$par))
+} else {
+	# jump here if only optimize over W
+	
+	
+	cat(
+		"\n****************",
+		"\n optimization over w weights: computing synthtic control unit \n",
+		"\n\n"
+	)
+	
+	if (nrow(X0) == 1)
+	{
+		custom.v <-
+			1 # this is the case where only one predictor is specified V is the identity matrix
+	} else {
+		# if user choose to supply v manually:
+		cat(
+			"\n****************",
+			"\n v weights supplied manually: computing synthtic control unit \n",
+			"\n\n"
+		)
+		if (length(custom.v) != nvarsV) {
+			stop("custom.V misspecified: length(custom.V) != nrow(X1)")
+		}
+		if (mode(custom.v) != "numeric") {
+			stop("custom.V must be numeric")
+		}
+	}
+	
+	# enter solution.V
+	rgV.optim  <- NULL
+	solution.v <- abs(custom.v) / sum(custom.v)
+	
+} # close else statment for by-passing V optimization
+
+# Print Solution
+
+solution.v
+
+# last step: now recover solution.w
+V <- diag(x = as.numeric(solution.v),
+					nrow = nvarsV,
+					ncol = nvarsV)
+H <- t(X0.scaled) %*% V %*% (X0.scaled)
+a <- X1.scaled
+c <- -1 * c(t(a) %*% V %*% (X0.scaled))
+A <- t(rep(1, length(c)))
+b <- 1
+l <- rep(0, length(c))
+u <- rep(1, length(c))
+r <- 0
+
+if (quadopt == "ipop") {
+	res <- kernlab::ipop(
+		c = c,
+		H = H,
+		A = A,
+		b = b,
+		l = l,
+		u = u,
+		r = r,
+		margin = Margin.ipop,
+		maxiter = 1000,
+		sigf = Sigf.ipop,
+		bound = Bound.ipop
+	)
+	solution.w <- as.matrix(primal(res))
+} else {
+	# LowRankQP
+	if (quadopt == "LowRankQP") {
+		res <-
+			LowRankQP::LowRankQP(
+				Vmat = H,
+				dvec = c,
+				Amat = A,
+				bvec = 1,
+				uvec = rep(1, length(c)),
+				method = "LU"
+			)
+		solution.w <- as.matrix(res$alpha)
+	}
+}
+
+rownames(solution.w) <- colnames(X0)
+colnames(solution.w) <- "w.weight"
+names(solution.v) <- rownames(X0)
+
+loss.w <- t(X1.scaled - X0.scaled %*% solution.w) %*%
+	V %*% (X1.scaled - X0.scaled %*% solution.w)
+
+loss.v <-
+	t(Z1 - Z0 %*% as.matrix(solution.w)) %*%
+	(Z1 - Z0 %*% as.matrix(solution.w))
+loss.v <- loss.v / nrow(Z0)
+
+# produce viewable output
+cat(
+	"\n****************",
+	"\n****************",
+	"\n****************",
+	"\n\nMSPE (LOSS V):",
+	loss.v,
+	#      "\n\nLOSS (W):", loss.w,
+	"\n\nsolution.v:\n",
+	round(as.numeric(solution.v), 10),
+	"\n\nsolution.w:\n",
+	round(as.numeric(solution.w), 10),
+	"\n\n"
+)
+
+optimize.out <- list(
+	solution.v = solution.v,
+	solution.w = solution.w,
+	loss.v = loss.v,
+	loss.w = loss.w,
+	custom.v = custom.v,
+	rgV.optim = rgV.optim
+)
+
+optimize.out
+
+


### PR DESCRIPTION
I created a separate file that pulled out the actual body of the `synth` function. This way we can step through each part. The only problem is that the optimizers are outside of the function, so that complicates things. 

Regardless, we see that the first optimization call fails silently (line 209). My suspicion is that it is because X0/ X0.scaled is not invertible (given the system tolerance for rank, test on line 205). This might be why the optimization engine can't optimize over these parameters. I imagine we could get around this issue by 
* changing the predictors so that there is less collinearity 
* altering the internals on the fn.V  
* More investigation into optimx::optim and seeing if we could change some settings to make the optimization work . 

Why does it work in Stata? I don't know. 